### PR TITLE
fix: handle 2D flux in SpectrumList

### DIFF
--- a/jdaviz/configs/specviz/plugins/parsers.py
+++ b/jdaviz/configs/specviz/plugins/parsers.py
@@ -304,16 +304,17 @@ def split_spectrum_with_2D_flux_array(data: Spectrum1D) -> SpectrumList:
 
     """
     new_data = SpectrumList()
+    meta = None
+    if data.meta is not None:
+        meta = data.meta
     for i in range(data.flux.shape[0]):
         unc = None
         mask = None
-        meta = None
         if data.uncertainty is not None:
             unc = data.uncertainty[i, :]
         if data.mask is not None:
             mask = data.mask[i, :]
-        if data.meta is not None:
-            meta = data.meta
+
         new_data.append(
             Spectrum1D(
                 spectral_axis=data.spectral_axis,


### PR DESCRIPTION
- now will unpack 2D flux in SpectrumList cases
- splitter now returns SpectrumList so as to pass through the SpectrumList validation cases
- moved to separate area of the code in the event anything else passes a 2D flux array (somehow)
- `data_label` case has been simplified down to SpectrumList case when a 2D flux Spectrum1D is encountered